### PR TITLE
CRITICAL vulnerability: bump jackson-databind from 2.9.9 to 2.9.9.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,11 +130,11 @@ shadowJar {
 
 dependencies {
     // base
-    compile 'joda-time:joda-time:2.9.9'
+    compile 'joda-time:joda-time:2.9.9.2'
 
     // persistence
     compile 'com.fasterxml.jackson.core:jackson-core:2.9.9.2'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.9'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.9.2'
 
     // networking
     compile 'com.squareup.okhttp3:okhttp:3.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ dependencies {
     compile 'joda-time:joda-time:2.9.9'
 
     // persistence
-    compile 'com.fasterxml.jackson.core:jackson-core:2.9.9'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.9.9.2'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.9'
 
     // networking


### PR DESCRIPTION
# Vulnerability Information

Bumps [jackson-databind](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.9.9) from 2.9.9 to 2.9.9.2.

Listed dependency **com.fasterxml.jackson.core:jackson-databind** contains vulnerable methods which are called from this project. This vulnerability appears to affect *jackson-databind* package versions lower than 2.9.9.2 (excluding). The vulnerability has been fixed in version 2.9.9.2, as can be seen from the linked CVE or package [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9) -
the micro-patch of 2.9.9.2 refers to the fix of this vulnerability.

| <center>Property</center> | <center>Value</center> |
|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
| <center> Linked CVE </center> | CVE-2019-14379                                                                                |
| <center> Number of affected methods </center> | 10+                                                                                                                |
| <center>Severity</center> | **CRITICAL**                                                                                                                                     |
| <center>Current version</center> | 2.9.9                                                                                                                                        |
| <center>Updated version</center> | 2.9.9.2                                                                                                                                    |
| <center>Backwards Compatibility</center> | True                                                                                                                         | 


# Vulnerable method calls

| Methods in this repository                                                    | Used package methods                                           | Origin vulnerable method                                          |
|----------|---------------------------------------|------------------------------------------------------------------------|
| [co.omise/<br>Serializer.deserializeFromMap(Map<String, Object> map, TypeReference<T> ref)][1] | com.fasterxml.jackson.databind/<br>ObjectMapper.convertValue(Object object, TypeReference<T> ref) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
  | [co.omise/<br>Serializer.serialize(OutputStream output, T model)][2] | com.fasterxml.jackson.databind/<br>ObjectMapper.writerFor(Class<T> valueType) | com.fasterxml.jackson.databind.introspect/<br>AnnotatedCreatorCollector.constructNonDefaultConstructor(ClassUtil.Ctor ctor, ClassUtil.Ctor mixin) |
| [co.omise/<br>Serializer.serializeParams(OutputStream output, T param)][3] | com.fasterxml.jackson.databind/<br>ObjectMapper.writerFor(Class<T> valueType) | com.fasterxml.jackson.databind.introspect/<br>AnnotatedCreatorCollector.constructNonDefaultConstructor(ClassUtil.Ctor ctor, ClassUtil.Ctor mixin) |


### Whole set of methods

To see the whole set of methods that are affected, please take a look at the table in the markdown file [here](https://github.com/MethodLevelAnalyzer/vulnerability-findings/blob/5336cede6c2fd00cea8636fa0b6fb1a2525d9b7b/results/gematik__ref-ePA-vauchannel__vauchannel-protocol____CVE-2019-14379.md).

[1]: https://github.com/omise/omise-java/blob/78cc5386e2977bad11bf1554e6b01ae646e98a8b/src/main/java/co/omise/Serializer.java#L151
[2]:  https://github.com/omise/omise-java/blob/8941ecaee0f42f9922ea4056b902380a3ee17c3f/src/main/java/co/omise/Serializer.java#L163
[3]:  https://github.com/omise/omise-java/blob/8941ecaee0f42f9922ea4056b902380a3ee17c3f/src/main/java/co/omise/Serializer.java#L175

### What do the columns represent?
The 1st column in the table indicates the method in this repository that was found to be affected by vulnerable methods from the *jackson-databind* package.

The 2nd column indicates the *jackson-databind* method that was directly called from this repository.

The 3rd column indicates the origin vulnerable method in the *jackson-databind* package. According to our dataset, this is one of the methods that produces the **CVE-2019-14379** vulnerability. This method was found to be internally chain-called in the *jackson-databind* package by the method listed in column 2.


### How were the results generated?
This vulnerability was analyzed specifically for usage in this project using the [FASTEN Project](https://www.fasten-project.eu/view/Main/). Statical method-level analysis was used to check for usage of vulnerable methods in the project.

Method calls between your project and *jackson-databind* have been mapped using a directed graph. From this graph, it could be then be seen whether any vulnerable *jackson-databind* methods are being called from within your project.

# Research Scope

We are a [team](https://github.com/orgs/TU-Delft-Research-Group-2021/people) of 3 BSc Computer Science students at the TU Delft. Our goal is to conduct research on how developers react to method-level vulnerability information that affects their projects. We would highly appreciate if you could help us with our research and please tick statements which apply to you below.

### First impression checklist
- [ ] I have read this pull request description.
- [ ] I was aware of this dependency vulnerability affecting my project before being informed by this Pull Request.
- [ ] I was convinced by the provided method information that this vulnerability indeed affects my project.
- [ ] After seeing the provided method-level information, I plan on fixing the vulnerability.

### After fixing vulnerability checklist
- [ ] I found that the provided method information has made my process of dealing with the vulnerable dependency easier.
- [ ] I have given priority to the task of fixing the vulnerability over other project tasks that are yet to be completed.
- [ ] I would like to receive this kind of method information in future vulnerable dependency Pull Request descriptions.

<img align="right" src="https://user-images.githubusercontent.com/52587121/119507191-e6226c80-bd6e-11eb-8c2a-306309777e0f.png" hspace="20" width="150"/>